### PR TITLE
drop env_prefix param, introduce env_var

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,19 @@ Add the following to your `pipeline.yml`:
 steps:
   - command: ./run_build.sh
     plugins:
-      - planetscale/vault-gcp-creds#v1.0.0:
+      - planetscale/vault-gcp-creds#v1.1.0:
           vault_addr: "https://my-vault-server"   # required
           path: "gcp"                             # optional. default "gcp"
           account_name: "my-pipeline"             # optional. default "bk-$BUILDKITE_PIPELINE_SLUG"
-          env_prefix: "BUILDKITE_"                # optional. default "" (prefix to add to CLOUDSDK_AUTH_ACCESS_TOKEN)
+          env_var: "CLOUDSDK_AUTH_ACCESS_TOKEN"   # optional. default "CLOUDSDK_AUTH_ACCESS_TOKEN"
 ```
 
 If authentication is successful the environment variables will be added to the environment:
 
 - `CLOUDSDK_AUTH_ACCESS_TOKEN`
 
-Setting the `env_prefix` property will add a prefix to each environment variable name, eg: `BUILDKITE_CLOUDSDK_AUTH_ACCESS_TOKEN`
+Set the `env_var` parameter to change the name of the environment variable, eg: `GOOGLE_OAUTH_ACCESS_TOKEN` for
+use with Terraform's Google Cloud provider.
 
 ## Ephemeral Credentials with vault-oidc-auth
 
@@ -37,7 +38,7 @@ steps:
     plugins:
       - planetscale/vault-oidc-auth#v1.0.0:
           vault_addr: "https://my-vault-server"
-      - planetscale/vault-gcp-creds#v1.0.0:
+      - planetscale/vault-gcp-creds#v1.1.0:
           vault_addr: "https://my-vault-server"
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,13 +10,13 @@ services:
       - 'shellcheck /plugin/hooks/*'
 
   lint-plugin:
-    image: buildkite/plugin-linter
+    image: buildkite/plugin-linter:v2.0.2
     volumes:
       - ".:/plugin:ro"
     command:
       - --id=planetscale/vault-gcp-creds
 
   tests:
-    image: buildkite/plugin-tester
+    image: buildkite/plugin-tester:v4.0.0
     volumes:
       - ".:/plugin:ro"

--- a/hooks/environment
+++ b/hooks/environment
@@ -13,19 +13,19 @@ main() {
   local addr="${BUILDKITE_PLUGIN_VAULT_GCP_CREDS_VAULT_ADDR:-}"
   local path="${BUILDKITE_PLUGIN_VAULT_GCP_CREDS_PATH:-gcp}"
   local account_name="${BUILDKITE_PLUGIN_VAULT_GCP_CREDS_ACCOUNT_NAME:-bk-$BUILDKITE_PIPELINE_SLUG}"
-  local prefix="${BUILDKITE_PLUGIN_VAULT_GCP_CREDS_ENV_PREFIX:-}"
+  local env_var="${BUILDKITE_PLUGIN_VAULT_GCP_CREDS_ENV_VAR:-CLOUDSDK_AUTH_ACCESS_TOKEN}"
 
   if [[ -z "$addr" ]]; then
     echo -e "~~~ :gcloud: ${brown}Vault GCP Creds Plugin${reset}. No 'vault_addr' specified. ${red}Skipping.${reset}"
     exit 0
   fi
 
-  json=$(vault \
+  token=$(vault \
     read \
-    -format=json \
+    -field=token \
     "${path}/impersonated-account/${account_name}/token"
   )
-  export "${prefix}CLOUDSDK_AUTH_ACCESS_TOKEN=$(jq -r '.data.token' <<<"$json")"
+  export "${env_var}=$token"
 
   echo -e "~~~ :gcloud: ${brown}Vault GCP Creds Plugin${reset}: ${green}OK${reset}: CLOUDSDK_AUTH_ACCESS_TOKEN added to the environment."
 }

--- a/plugin.yml
+++ b/plugin.yml
@@ -4,7 +4,6 @@ author: https://github.com/planetscale
 requirements:
   - bash
   - vault
-  - jq
 configuration:
   properties:
     vault_addr:
@@ -13,7 +12,7 @@ configuration:
       type: string
     account_name:
       type: string
-    env_prefix:
+    env_var:
       type: string
   required:
     - vault_addr

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -21,7 +21,7 @@ setup() {
   export BUILDKITE_PLUGIN_VAULT_GCP_CREDS_VAULT_ADDR="http://vault:8200"
 
   stub vault \
-    'read -format=json gcp/impersonated-account/bk-foo/token : cat tests/fixtures/vault-post-token.json'
+    'read -field=token gcp/impersonated-account/bk-foo/token : echo ya29.c.b0AT7lpjBRmO7ghBEyMV18evd016hq'
 
   run bash -c "source $PWD/hooks/environment && env | sort"
   assert_success
@@ -38,20 +38,20 @@ setup() {
   export BUILDKITE_PLUGIN_VAULT_GCP_CREDS_VAULT_ADDR="http://vault:8200"
   export BUILDKITE_PLUGIN_VAULT_GCP_CREDS_PATH="gcp-creds"
   export BUILDKITE_PLUGIN_VAULT_GCP_CREDS_ACCOUNT_NAME="bar"
-  export BUILDKITE_PLUGIN_VAULT_GCP_CREDS_ENV_PREFIX="BUILDKITE_"
+  export BUILDKITE_PLUGIN_VAULT_GCP_CREDS_ENV_VAR="GOOGLE_OAUTH_ACCESS_TOKEN"
 
   stub vault \
-    'read -format=json gcp-creds/impersonated-account/bar/token : cat tests/fixtures/vault-post-token.json'
+    'read -field=token gcp-creds/impersonated-account/bar/token : echo ya29.c.b0AT7lpjBRmO7ghBEyMV18evd016hq'
 
   run bash -c "source $PWD/hooks/environment && env | sort"
   assert_success
-  assert_output --partial "BUILDKITE_CLOUDSDK_AUTH_ACCESS_TOKEN=ya29.c.b0AT7lpjBRmO7ghBEyMV18evd016hq"
+  assert_output --partial "GOOGLE_OAUTH_ACCESS_TOKEN=ya29.c.b0AT7lpjBRmO7ghBEyMV18evd016hq"
 
   unset BUILDKITE_PIPELINE_SLUG
   unset BUILDKITE_PLUGIN_VAULT_GCP_CREDS_VAULT_ADDR
   unset BUILDKITE_PLUGIN_VAULT_GCP_CREDS_PATH
   unset BUILDKITE_PLUGIN_VAULT_GCP_CREDS_ACCOUNT_NAME
-  unset BUILDKITE_PLUGIN_VAULT_GCP_CREDS_ENV_PREFIX
+  unset BUILDKITE_PLUGIN_VAULT_GCP_CREDS_ENV_VAR
 
   unset BUILDKITE_CLOUDSDK_AUTH_ACCESS_TOKEN
 }

--- a/tests/fixtures/vault-post-token.json
+++ b/tests/fixtures/vault-post-token.json
@@ -1,7 +1,0 @@
-{
-  "data": {
-    "expires_at_seconds": 1671667844,
-    "token": "ya29.c.b0AT7lpjBRmO7ghBEyMV18evd016hq",
-    "token_ttl": "59m59s"
-  }
-}


### PR DESCRIPTION
Drop the `env_prefix` flag carried over from our vault-aws-creds plugin.

The GCP plugin only sets a single env var while the AWS plugin must set multiple env vars so there is not the same need for the prefix.

The caller can choose the environment var to set by specifying the `env_var` param. The default remains as `CLOUDSDK_AUTH_ACCESS_TOKEN`