### PR TITLE
Bump vault-oidc-auth version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ to provide short-lived credentials for accessing Vault and GCP. Example:
 steps:
   - command: ./run_build.sh
     plugins:
-      - planetscale/vault-oidc-auth#v1.0.0:
+      - planetscale/vault-oidc-auth#v1.1.1:
           vault_addr: "https://my-vault-server"
       - planetscale/vault-gcp-creds#v1.1.1:
           vault_addr: "https://my-vault-server"


### PR DESCRIPTION
Brings in the changes from https://github.com/planetscale/vault-oidc-auth-buildkite-plugin/pull/29 to send the organization ID as a JWT claim.